### PR TITLE
feat(shapefile): scraper that take geojson data and generate a shapefile base on that dataset

### DIFF
--- a/scrapers/Anderson.mjs
+++ b/scrapers/Anderson.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Anderson', async () => {
     const baseUrl =
       'https://propertyviewer.andersoncountysc.org/arcgis/rest/services/Parcel_Sales/MapServer';
-    const dataUrl = `${baseUrl}/0`;
+    const layerNumber = 0;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Beaufort.mjs
+++ b/scrapers/Beaufort.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Beaufort', async () => {
     const baseUrl =
       'https://gis.beaufortcountysc.gov/server/rest/services/ParcelsWithAssessorData/MapServer';
-    const dataUrl = `${baseUrl}/0`;
+    const layerNumber = 0;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Berkeley.mjs
+++ b/scrapers/Berkeley.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Berkeley', async () => {
     const baseUrl =
       'https://gis.berkeleycountysc.gov/arcgis/rest/services/desktop/internet_map/MapServer';
-    const dataUrl = `${baseUrl}/3`;
+    const layerNumber = 3;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Charleston.mjs
+++ b/scrapers/Charleston.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Charleston', async () => {
     const baseUrl =
       'https://gisccapps.charlestoncounty.org/arcgis/rest/services/GIS_VIEWER/Public_Search/MapServer';
-    const dataUrl = `${baseUrl}/4`;
+    const layerNumber = 4;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Clayton.mjs
+++ b/scrapers/Clayton.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Clayton', async () => {
     const baseUrl =
       'https://weba.co.clayton.ga.us:5443/server/rest/services/PlanningZoning/ZoningData/MapServer';
-    const dataUrl = `${baseUrl}/5`;
+    const layerNumber = 5;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Columbia.mjs
+++ b/scrapers/Columbia.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Columbia', async () => {
     const baseUrl =
       'https://mapsonline.columbiacountyga.gov/arcgis/rest/services/Map_LayersJS/MapServer';
-    const dataUrl = `${baseUrl}/68`;
+    const layerNumber = 68;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Darlington.mjs
+++ b/scrapers/Darlington.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Darlington', async () => {
     const baseUrl =
       'https://services5.arcgis.com/8FJikaProY6O3ncx/ArcGIS/rest/services/PARCELS/FeatureServer';
-    const dataUrl = `${baseUrl}/0`;
+    const layerNumber = 0;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/DentonTx.mjs
+++ b/scrapers/DentonTx.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'DentonTx', async () => {
     const baseUrl =
       'https://gis.cityofdenton.com:9002/arcgis/rest/services/MapViewer/Property/MapServer';
-    const dataUrl = `${baseUrl}/2`;
+    const layerNumber = 2;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Dorchester.mjs
+++ b/scrapers/Dorchester.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Dorchester', async () => {
     const baseUrl =
       'https://gisservices.dorchestercounty.net/arcgis/rest/services/Locations/Parcels_Only/MapServer';
-    const dataUrl = `${baseUrl}/0`;
+    const layerNumber = 0;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/FortLauderdaleFl.mjs
+++ b/scrapers/FortLauderdaleFl.mjs
@@ -3,9 +3,9 @@ import { mapserver } from '../util/MapServer.mjs';
 export default ({ database, DataScraper }) => {
   return DataScraper(database, 'FortLauderdaleFl', async () => {
     const baseUrl = 'https://gis.fortlauderdale.gov/server/rest/services/TaxParcel/MapServer';
-    const dataUrl = `${baseUrl}/0`;
+    const layerNumber = 0;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Gwinnett.mjs
+++ b/scrapers/Gwinnett.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Gwinnett', async () => {
     const baseUrl =
       'https://gis3.gwinnettcounty.com/mapvis/rest/services/OnPoint/GC_Parcel/MapServer';
-    const dataUrl = `${baseUrl}/9`;
+    const layerNumber = 9;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Horry.mjs
+++ b/scrapers/Horry.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Horry', async () => {
     const baseUrl =
       'https://www.horrycounty.org/gisweb/rest/services/OpenData/Parcel_Geometry/MapServer';
-    const dataUrl = `${baseUrl}/0`;
+    const layerNumber = 0;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Lexington.mjs
+++ b/scrapers/Lexington.mjs
@@ -3,9 +3,9 @@ import { mapserver } from '../util/MapServer.mjs';
 export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Lexington', async () => {
     const baseUrl = 'https://maps.lex-co.com/agstserver/rest/services/Property/MapServer';
-    const dataUrl = `${baseUrl}/4`;
+    const layerNumber = 4;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Liberty.mjs
+++ b/scrapers/Liberty.mjs
@@ -3,9 +3,9 @@ import { mapserver } from '../util/MapServer.mjs';
 export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Liberty', async () => {
     const baseUrl = 'https://gis.libertycountyga.com/arcgis/rest/services/Parcels/MapServer';
-    const dataUrl = `${baseUrl}/0`;
+    const layerNumber = 0;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/NashvilleTn.mjs
+++ b/scrapers/NashvilleTn.mjs
@@ -3,9 +3,9 @@ import { mapserver } from '../util/MapServer.mjs';
 export default ({ database, DataScraper }) => {
   return DataScraper(database, 'NashvilleTn', async () => {
     const baseUrl = 'https://maps.nashville.gov/arcgis/rest/services/Cadastral/Parcels/MapServer';
-    const dataUrl = `${baseUrl}/0`;
+    const layerNumber = 0;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/OklahomaCityOk.mjs
+++ b/scrapers/OklahomaCityOk.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'OklahomaCityOk', async () => {
     const baseUrl =
       'https://oklahomacounty.geocortex.com/arcgis/rest/services/ParcelData/OklahomaCountyAllParcelsData4/MapServer';
-    const dataUrl = `${baseUrl}/10`;
+    const layerNumber = 10;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Paulding.mjs
+++ b/scrapers/Paulding.mjs
@@ -3,9 +3,9 @@ import { mapserver } from '../util/MapServer.mjs';
 export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Paulding', async () => {
     const baseUrl = 'https://arcgis5.roktech.net/arcgis/rest/services/Paulding/GoMaps4/MapServer';
-    const dataUrl = `${baseUrl}/36`;
+    const layerNumber = 36;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Richmond.mjs
+++ b/scrapers/Richmond.mjs
@@ -3,9 +3,9 @@ import { mapserver } from '../util/MapServer.mjs';
 export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Richmond', async () => {
     const baseUrl = 'https://gismap.augustaga.gov/arcgis/rest/services/Map_LayersJS/MapServer';
-    const dataUrl = `${baseUrl}/316`;
+    const layerNumber = 316;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/SacramentoCa.mjs
+++ b/scrapers/SacramentoCa.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'SacramentoCa', async () => {
     const baseUrl =
       'https://services1.arcgis.com/5NARefyPVtAeuJPU/ArcGIS/rest/services/Parcels/FeatureServer';
-    const dataUrl = `${baseUrl}/0`;
+    const layerNumber = 0;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Saluda.mjs
+++ b/scrapers/Saluda.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Saluda', async () => {
     const baseUrl =
       'https://saludacountysc.net/arcgis/rest/services/ParcelViewers/PublicWebsite/MapServer';
-    const dataUrl = `${baseUrl}/4`;
+    const layerNumber = 4;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Sumter.mjs
+++ b/scrapers/Sumter.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Sumter', async () => {
     const baseUrl =
       'http://svr4.sumtercountysc.org:6080/arcgis/rest/services/Parcel_Search/Parcel_Base/MapServer';
-    const dataUrl = `${baseUrl}/0`;
+    const layerNumber = 0;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/VirginiaBeachVa.mjs
+++ b/scrapers/VirginiaBeachVa.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'VirginiaBeachVa', async () => {
     const baseUrl =
       'https://gismaps.vbgov.com/arcgis/rest/services/Basemaps/PropertyInformation/MapServer';
-    const dataUrl = `${baseUrl}/12`;
+    const layerNumber = 12;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/scrapers/Whitfield.mjs
+++ b/scrapers/Whitfield.mjs
@@ -4,9 +4,9 @@ export default ({ database, DataScraper }) => {
   return DataScraper(database, 'Whitfield', async () => {
     const baseUrl =
       'https://gis.whitfieldcountyga.com/server/rest/services/Parcels_and_Development/MapServer';
-    const dataUrl = `${baseUrl}/5`;
+    const layerNumber = 5;
 
-    const results = await mapserver({ baseUrl, dataUrl });
+    const results = await mapserver({ baseUrl, layerNumber });
 
     return results;
   });

--- a/util/MapServer.mjs
+++ b/util/MapServer.mjs
@@ -1,28 +1,20 @@
 import fetch from 'node-fetch';
 
-export const mapserver = async payload => {
+export const mapserver = async ({ baseUrl, layerNumber }) => {
   const results = [];
-  const { baseUrl, dataUrl } = payload;
-
   const request = await fetch(`${baseUrl}/info/itemInfo?f=json`);
   const response = await request.json();
 
   const { description, snippet, title } = response;
 
-  const geoJson = `${dataUrl}/query?where=1=1&f=json`;
-
-  let sanitizeDescriptionHtml = '';
-
-  if (description) {
-    sanitizeDescriptionHtml = description.replace(/(<([^>]+)>)/gi, '');
-  }
+  const geoJson = `${baseUrl}/${layerNumber}/query?where=1=1&f=json`;
 
   results.push({
     url: geoJson,
     updated: 0,
     created: 0,
-    description: sanitizeDescriptionHtml,
-    name: snippet || title,
+    description: description || '',
+    name: snippet || title || '',
   });
 
   return results;


### PR DESCRIPTION
These scrapers are utilizing ags-stream(https://www.npmjs.com/package/ags-stream) to create a readable stream of GeoJSON Features from an ArcGIS Server instance. This can be useful for scraping records from any ArcGIS Server or any other ETL process. After all GeoJSON data is captured we use geojson2shp(https://github.com/jdesboeufs/geojson2shp) to convert GeoJSON into Shapefile.

The process to capture all GeoJSON from a defined MapServer can take quite some time. This should be run on a separate pipeline. This is the reason why I have it in a folder called geojson so it would not hold up the normal scraper workflow.